### PR TITLE
Adequacao dos parametros originais no mixin de 'place-order-action'

### DIFF
--- a/view/frontend/web/js/action/place-order-mixin.js
+++ b/view/frontend/web/js/action/place-order-mixin.js
@@ -6,7 +6,7 @@ define([
     'use strict';
 
     return function (placeOrderAction) {
-        return wrapper.wrap(placeOrderAction, function (originalAction, messageContainer) {
+        return wrapper.wrap(placeOrderAction, function (originalAction, paymentData, messageContainer) {
             var billingAddress = quote.billingAddress();
 
             if (billingAddress['extension_attributes'] === undefined) {
@@ -23,7 +23,7 @@ define([
                 });
             }
 
-            return originalAction(messageContainer);
+            return originalAction(paymentData, messageContainer);
         });
     };
 });


### PR DESCRIPTION
Existe um bug gerado pelo módulo que resulta em um efeito colateral nas mensagens de erro nos módulos de pagamento exibidos no checkout. A causa do problema é um mixin do módulo BrazilCustomerCode: [SystemCode_BrazilCustomerAttributes/js/action/place-order-mixin](https://github.com/m2-systemcode/BrazilCustomerAttributes/blob/master/view/frontend/requirejs-config.js).

O mixin adicionado ao Js [Magento_Checkout/js/action/place-order](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js) não passa todos parâmetros para a função original e a referência ao messageContainer é quebrada. Os parâmetros da versão [2.1 para cá](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js) são dois: paymentData e messageContainer, respectivamente. Todavia, [ele só passa o primeiro](https://github.com/m2-systemcode/BrazilCustomerAttributes/blob/master/view/frontend/web/js/action/place-order-mixin.js): o paymentData, chamando-o erroneamente de messageContainer.

Na versão [2.0](https://github.com/magento/magento2/blob/2.0/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js) do Magento, esta função recebia três parâmetros, em lugar de dois. Ou seja, não observei versão que recebesse apenas um parâmetro. Portanto, imagino que seja um erro na elaboração do plugin da SystemCode.

O problema de não passar a referência corretamente ao messageContainer desemboca na chamada do errorProcessor com o parâmetro messageContainer sendo nulo em [Magento_Checkout/js/action/place-order](https://github.com/magento/magento2/blob/f69a8ee1585161e31c3ad97df64cab74f03c1bee/app/code/Magento/Checkout/view/frontend/web/js/model/place-order.js#L32) e portanto o errorProcessor [utiliza a referência do container padrão do Magento](https://github.com/magento/magento2/blob/f69a8ee1585161e31c3ad97df64cab74f03c1bee/app/code/Magento/Checkout/view/frontend/web/js/model/error-processor.js#L24), mostrando a mensagem no topo da página.

Testei a alteração do mixin passando os parâmetros corretamente para ver se corrigia o problema e tudo correu bem.