### PR TITLE
Corrige troca de campos de endereço (complemento e bairro) e tratamento de erro no address-mixin.js

### DIFF
--- a/Block/Magento/Customer/Widget/Street.php
+++ b/Block/Magento/Customer/Widget/Street.php
@@ -69,7 +69,7 @@ class Street extends \Magento\Customer\Block\Widget\AbstractWidget
      */
     public function getThirdLineNeighborhood()
     {
-        return $this->helper->getConfig("brazilcustomerattributes/general/line_complement");
+        return $this->helper->getConfig("brazilcustomerattributes/general/line_neighborhood");
     }
 
     /**
@@ -78,7 +78,7 @@ class Street extends \Magento\Customer\Block\Widget\AbstractWidget
      */
     public function getFourthLineComplement()
     {
-        return $this->helper->getConfig("brazilcustomerattributes/general/line_neighborhood");
+        return $this->helper->getConfig("brazilcustomerattributes/general/line_complement");
     }
 
 }

--- a/Block/Magento/Customer/Widget/Streetedit.php
+++ b/Block/Magento/Customer/Widget/Streetedit.php
@@ -98,7 +98,7 @@ class Streetedit extends \Magento\Customer\Block\Address\Edit
      */
     public function getThirdLineNeighborhood()
     {
-        return $this->helper->getConfig("brazilcustomerattributes/general/line_complement");
+        return $this->helper->getConfig("brazilcustomerattributes/general/line_neighborhood");
     }
 
     /**
@@ -107,7 +107,7 @@ class Streetedit extends \Magento\Customer\Block\Address\Edit
      */
     public function getFourthLineComplement()
     {
-        return $this->helper->getConfig("brazilcustomerattributes/general/line_neighborhood");
+        return $this->helper->getConfig("brazilcustomerattributes/general/line_complement");
     }
 
 }

--- a/Plugin/Checkout/LayoutProcessor.php
+++ b/Plugin/Checkout/LayoutProcessor.php
@@ -109,20 +109,20 @@ class LayoutProcessor
         }
 
         // Street Line 2
-        if($this->helper->getConfig("brazilcustomerattributes/general/line_complement")
-                && $numStreetLines >= 3) {
-            $shippingAddressFieldsetChild['street']['children'][2]['label'] = __('Complement');
-        }
-        
-        // Street Line 3
         if($this->helper->getConfig("brazilcustomerattributes/general/line_neighborhood")
                 && $numStreetLines >= 4) {
-            $shippingAddressFieldsetChild['street']['children'][3]['label'] = __('Neighborhood');
-            $shippingAddressFieldsetChild['street']['children'][3]['validation'] = [
+            $shippingAddressFieldsetChild['street']['children'][2]['label'] = __('Neighborhood');
+            $shippingAddressFieldsetChild['street']['children'][2]['validation'] = [
                 'required-entry' => true,
                 'min_text_length' => 1,
                 'max_text_length' => 255
             ];
+        }
+
+        // Street Line 3
+        if($this->helper->getConfig("brazilcustomerattributes/general/line_complement")
+                && $numStreetLines >= 3) {
+            $shippingAddressFieldsetChild['street']['children'][3]['label'] = __('Complement');
         }
 
         // Street Prefix
@@ -214,21 +214,21 @@ class LayoutProcessor
                 }
 
                 // Street Line 2
-                if($this->helper->getConfig("brazilcustomerattributes/general/line_complement")
-                        && $numStreetLines >= 3) {
-                    $paymentFormChildren['street']['children'][2]['label'] = __('Complement');
-                }
-
-                // Street Line 3
                 if($this->helper->getConfig("brazilcustomerattributes/general/line_neighborhood")
                         && $numStreetLines >= 4) {
-                    $paymentFormChildren['street']['children'][3]['label'] = __('Neighborhood');
-                    $paymentFormChildren['street']['children'][3]['validation'] = [
+                    $paymentFormChildren['street']['children'][2]['label'] = __('Neighborhood');
+                    $paymentFormChildren['street']['children'][2]['validation'] = [
                         'required-entry' => true,
                         'min_text_length' => 1,
                         'max_text_length' => 255
                     ];
-                }
+                }                
+
+                // Street Line 3
+                if($this->helper->getConfig("brazilcustomerattributes/general/line_complement")
+                        && $numStreetLines >= 3) {
+                    $paymentFormChildren['street']['children'][3]['label'] = __('Complement');
+                }                
 
                 // Street Prefix
                 if($this->helper->getConfig("brazilcustomerattributes/general/prefix_enabled")) {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ricardomartins/brazilcustomerattributes",
+    "name": "robsoned/brazilcustomerattributes",
     "description":"Magento 2 module to adapt customer and address fields to brazil.",
     "keywords": [
         "magento 2",
@@ -16,18 +16,14 @@
     "require": {
         "magento/module-backend": "100.0.*|100.1.*|100.2.*|101.0.*|102.*",
         "magento/framework": "100.0.*|100.1.*|101.0.*|102.0.*|103.0.*",
-        "ricardomartins/brazilzipcode": "*"
+        "robsoned/brazilzipcode": "*"
     },
     "type": "magento2-module",
     "version": "1.1.7",
     "license": [
         "OSL-3.0"
     ],
-    "homepage": "https://www.systemcode.com.br/",
-    "support": {
-        "email": "contato@systemcode.com.br",
-        "issues": "https://github.com/eduardoddias/Magento-SystemCode_BrazilCustomerAttributes/issues/"
-    },
+    "homepage": "https://github.com/robsoned/Magento-SystemCode_BrazilCustomerAttributes",
     "authors": [
         {
             "name": "Eduardo Diogo Dias",
@@ -40,7 +36,12 @@
             "email": "ricardo@magenteiro.com",
             "homepage": "https://magenteiro.com/",
             "role": "Developer"
-        }
+        },
+        {
+            "name": "Robson Santos",            
+            "homepage": "https://github.com/robsoned/Magento-SystemCode_BrazilCustomerAttributes",
+            "role": "Developer"
+        }    
     ],
     "autoload": {
         "files": [

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ PS: This module doesn't work with checkout as guest.
 
 #### ✓ Install by Composer (recommended)
 ```
-composer require systemcode/brazilcustomerattributes
+composer require robsoned/brazilcustomerattributes
 php bin/magento module:enable SystemCode_BrazilCustomerAttributes SystemCode_Base
 php bin/magento setup:upgrade
 ```
@@ -74,7 +74,7 @@ OBS: O módulo não funciona com checkout como visitante.
 
 #### ✓ Instalação via Composer (recomendado)
 ```
-composer require systemcode/brazilcustomerattributes
+composer require robsoned/brazilcustomerattributes
 php bin/magento module:enable
 php bin/magento setup:upgrade
 ```

--- a/view/frontend/templates/widget/street.phtml
+++ b/view/frontend/templates/widget/street.phtml
@@ -34,10 +34,10 @@
     <?php if($_streetLines>=3): ?>
         <br>
         <?php if($block->getThirdLineNeighborhood()): ?>
-            <label for="street_3" class="label"><span><?php /* @escapeNotVerified */ echo __('Complement') ?></span></label>
+            <label for="street_3" class="label"><span><?php /* @escapeNotVerified */ echo __('Neighborhood') ?></span></label>
         <?php endif; ?>
         <div class="control">
-            <input type="text" name="street[2]" value="<?php echo $block->escapeHtml($block->getStreetLine(3)) ?>" title="<?php /* @escapeNotVerified */ echo __('Complement') ?>" id="street_3" class="input-text"  />
+            <input type="text" name="street[2]" value="<?php echo $block->escapeHtml($block->getStreetLine(3)) ?>" title="<?php /* @escapeNotVerified */ echo __('Neighborhood') ?>" id="street_3" class="input-text"  />
         </div>
     <?php endif; ?>
 </div>
@@ -45,10 +45,10 @@
     <?php if($_streetLines==4): ?>
         <br>
         <?php if($block->getFourthLineComplement()): ?>
-            <label for="street_4" class="label"><span><?php /* @escapeNotVerified */ echo __('Neighborhood') ?></span></label>
+            <label for="street_4" class="label"><span><?php /* @escapeNotVerified */ echo __('Complement') ?></span></label>
         <?php endif; ?>
         <div class="control">
-            <input type="text" name="street[3]" value="<?php echo $block->escapeHtml($block->getStreetLine(4)) ?>" title="<?php /* @escapeNotVerified */ echo __('Neighborhood') ?>" id="street_4" class="input-text required-entry"  />
+            <input type="text" name="street[3]" value="<?php echo $block->escapeHtml($block->getStreetLine(4)) ?>" title="<?php /* @escapeNotVerified */ echo __('Complement') ?>" id="street_4" class="input-text required-entry"  />
         </div>
     <?php endif; ?>
 </div>

--- a/view/frontend/web/js/form/address-mixin.js
+++ b/view/frontend/web/js/form/address-mixin.js
@@ -20,8 +20,8 @@ require([
                 // TODO
             }else{
                 $("#street_1").val(data.street??'');
-                $("#street_3").val(data.additional_info??'');
-                $("#street_4").val(data.neighborhood??'');
+                $("#street_3").val(data.neighborhood??'');
+                $("#street_4").val(data.additional_info??'');
                 $("#city").val(data.city??'');
                 $("#country").val('BR');
                 $("#region_id").val(data.region_id??'');

--- a/view/frontend/web/js/form/address-mixin.js
+++ b/view/frontend/web/js/form/address-mixin.js
@@ -26,7 +26,7 @@ require([
                 $("#country").val('BR');
                 $("#region_id").val(data.region_id??'');
             }
-        }).error(function(){});
+        }).fail(function(){});
 
         $('body').loader('hide');
     });

--- a/view/frontend/web/js/shipping-address/address-renderer/zip-code.js
+++ b/view/frontend/web/js/shipping-address/address-renderer/zip-code.js
@@ -80,10 +80,10 @@ define([
                             registry.get(element.parentName + '.' + 'street.0').value(data.street ?? '');
                         }
                         if(registry.get(element.parentName + '.' + 'street.2')){
-                            registry.get(element.parentName + '.' + 'street.2').value(data.additional_info ?? '');
+                            registry.get(element.parentName + '.' + 'street.2').value(data.neighborhood ?? '');
                         }
                         if(registry.get(element.parentName + '.' + 'street.3')){
-                            registry.get(element.parentName + '.' + 'street.3').value(data.neighborhood ?? '');
+                            registry.get(element.parentName + '.' + 'street.3').value(data.additional_info ?? '');
                         }
                         if(registry.get(element.parentName + '.' + 'city')){
                             registry.get(element.parentName + '.' + 'city').value(data.city ?? '');


### PR DESCRIPTION
O campo "Complemento" e o campo "Bairro" estão invertidos no cadastro de endereço do cliente e no checkout. Esta correção garante que os dados sejam inseridos e exibidos corretamente.

<img src="https://github.com/user-attachments/assets/3a7ef8d5-ec4f-4157-8b41-f02d729a6dfe" width="230px">

<img src="https://github.com/user-attachments/assets/7534055e-d1a8-454c-a6c4-a5ee3a695ed2" width="500px">




